### PR TITLE
keyval, QS, Headers, URL, MediaType

### DIFF
--- a/pkg/apis/wsecurity/v1alpha1/httpHeaders.go
+++ b/pkg/apis/wsecurity/v1alpha1/httpHeaders.go
@@ -1,0 +1,92 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"net/http"
+)
+
+//////////////////// HeadersProfile ////////////////
+
+// Exposes ValueProfile interface
+type HeadersProfile struct {
+	Kv KeyValProfile `json:"kv"`
+}
+
+func (profile *HeadersProfile) profileI(args ...interface{}) {
+	profile.Profile(args[0].(http.Header))
+}
+
+func (profile *HeadersProfile) Profile(headers http.Header) {
+	profile.Kv.ProfileMapStringSlice(headers)
+}
+
+//////////////////// HeadersPile ////////////////
+
+// Exposes ValuePile interface
+type HeadersPile struct {
+	Kv *KeyValPile `json:"kv"`
+}
+
+func (pile *HeadersPile) addI(valProfile ValueProfile) {
+	pile.Add(valProfile.(*HeadersProfile))
+}
+
+func (pile *HeadersPile) Add(profile *HeadersProfile) {
+	if pile.Kv == nil {
+		pile.Kv = new(KeyValPile)
+	}
+	pile.Kv.Add(&profile.Kv)
+}
+
+func (pile *HeadersPile) mergeI(otherValPile ValuePile) {
+	pile.Merge(otherValPile.(*HeadersPile))
+}
+
+func (pile *HeadersPile) Merge(otherPile *HeadersPile) {
+	if pile.Kv == nil {
+		pile.Kv = new(KeyValPile)
+	}
+	pile.Kv.Merge(otherPile.Kv)
+}
+
+func (pile *HeadersPile) Clear() {
+	pile.Kv = new(KeyValPile)
+	if pile.Kv != nil {
+		pile.Kv.Clear()
+	}
+}
+
+//////////////////// HeadersConfig ////////////////
+
+// Exposes ValueConfig interface
+type HeadersConfig struct {
+	Kv KeyValConfig `json:"kv"`
+}
+
+func (config *HeadersConfig) decideI(valProfile ValueProfile) string {
+	return config.Decide(valProfile.(*HeadersProfile))
+}
+
+func (config *HeadersConfig) Decide(profile *HeadersProfile) string {
+	str := config.Kv.Decide(&profile.Kv)
+	if str == "" {
+		return str
+	}
+	return fmt.Sprintf("KeyVal: %s", str)
+}
+
+func (config *HeadersConfig) learnI(valPile ValuePile) {
+	config.Learn(valPile.(*HeadersPile))
+}
+
+func (config *HeadersConfig) Learn(pile *HeadersPile) {
+	config.Kv.Learn(pile.Kv)
+}
+
+func (config *HeadersConfig) fuseI(otherValConfig ValueConfig) {
+	config.Fuse(otherValConfig.(*HeadersConfig))
+}
+
+func (config *HeadersConfig) Fuse(otherConfig *HeadersConfig) {
+	config.Kv.Fuse(&otherConfig.Kv)
+}

--- a/pkg/apis/wsecurity/v1alpha1/httpHeaders_test.go
+++ b/pkg/apis/wsecurity/v1alpha1/httpHeaders_test.go
@@ -1,0 +1,34 @@
+package v1alpha1
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHeaders_V1(t *testing.T) {
+	header := http.Header{}
+	header.Add("a", "x")
+	header2 := http.Header{}
+	header2.Add("b", "x")
+	arguments := [][]http.Header{
+		{header},
+		{header2},
+		{header2},
+		{header},
+		{header},
+		{header},
+	}
+	var args []interface{}
+	var profiles []ValueProfile
+	var piles []ValuePile
+	var configs []ValueConfig
+	for i := 0; i < 10; i++ {
+		profiles = append(profiles, new(HeadersProfile))
+		piles = append(piles, new(HeadersPile))
+		configs = append(configs, new(HeadersConfig))
+	}
+	for i := 0; i < len(arguments); i++ {
+		args = append(args, arguments[i])
+	}
+	ValueTests_All(t, profiles, piles, configs, args...)
+}

--- a/pkg/apis/wsecurity/v1alpha1/httpMediaType.go
+++ b/pkg/apis/wsecurity/v1alpha1/httpMediaType.go
@@ -1,0 +1,102 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"mime"
+)
+
+//////////////////// MediaTypeProfile ////////////////
+
+// Exposes ValueProfile interface
+// TypeToken include rfc7231 type "/" subtype
+type MediaTypeProfile struct {
+	TypeTokens SetProfile    `json:"type"`   // "text/html"
+	Params     KeyValProfile `json:"params"` // {"charset": "utf-8"}
+}
+
+func (profile *MediaTypeProfile) profileI(args ...interface{}) {
+	profile.Profile(args[0].(string))
+}
+
+func (profile *MediaTypeProfile) Profile(str string) {
+	if mediaType, params, err := mime.ParseMediaType(str); err == nil && mediaType != "" {
+		profile.TypeTokens.ProfileString(mediaType)
+		profile.Params.ProfileMapString(params)
+		return
+	}
+	// For clients that fail to send media type
+	profile.TypeTokens.ProfileString("none")
+	profile.Params.ProfileMapString(nil)
+}
+
+//////////////////// MediaTypePile ////////////////
+
+// Exposes ValuePile interface
+type MediaTypePile struct {
+	TypeTokens SetPile    `json:"type"`
+	Params     KeyValPile `json:"params"`
+}
+
+func (pile *MediaTypePile) addI(valProfile ValueProfile) {
+	pile.Add(valProfile.(*MediaTypeProfile))
+}
+
+func (pile *MediaTypePile) Add(profile *MediaTypeProfile) {
+	pile.TypeTokens.Add(&profile.TypeTokens)
+	pile.Params.Add(&profile.Params)
+}
+
+func (pile *MediaTypePile) mergeI(otherValPile ValuePile) {
+	pile.Merge(otherValPile.(*MediaTypePile))
+}
+
+func (pile *MediaTypePile) Merge(otherPile *MediaTypePile) {
+	pile.TypeTokens.Merge(&otherPile.TypeTokens)
+	pile.Params.Merge(&otherPile.Params)
+}
+
+func (pile *MediaTypePile) Clear() {
+
+	pile.TypeTokens.Clear()
+	pile.Params.Clear()
+}
+
+//////////////////// MediaTypeConfig ////////////////
+
+// Exposes ValueConfig interface
+type MediaTypeConfig struct {
+	TypeTokens SetConfig    `json:"type"`
+	Params     KeyValConfig `json:"params"`
+}
+
+func (config *MediaTypeConfig) decideI(valProfile ValueProfile) string {
+	return config.Decide(valProfile.(*MediaTypeProfile))
+}
+
+func (config *MediaTypeConfig) Decide(profile *MediaTypeProfile) string {
+	if str := config.TypeTokens.Decide(&profile.TypeTokens); str != "" {
+		return fmt.Sprintf("Type: %s", str)
+	}
+	if str := config.Params.Decide(&profile.Params); str != "" {
+		return fmt.Sprintf("Params: %s", str)
+	}
+	return ""
+}
+
+func (config *MediaTypeConfig) learnI(valPile ValuePile) {
+	config.Learn(valPile.(*MediaTypePile))
+}
+
+func (config *MediaTypeConfig) Learn(pile *MediaTypePile) {
+	config.TypeTokens.Learn(&pile.TypeTokens)
+	config.Params.Learn(&pile.Params)
+}
+
+func (config *MediaTypeConfig) fuseI(otherValConfig ValueConfig) {
+	config.Fuse(otherValConfig.(*MediaTypeConfig))
+}
+
+func (config *MediaTypeConfig) Fuse(otherConfig *MediaTypeConfig) {
+	config.TypeTokens.Fuse(&otherConfig.TypeTokens)
+	config.Params.Fuse(&otherConfig.Params)
+}

--- a/pkg/apis/wsecurity/v1alpha1/httpMediaType_test.go
+++ b/pkg/apis/wsecurity/v1alpha1/httpMediaType_test.go
@@ -1,0 +1,37 @@
+package v1alpha1
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMediaType(t *testing.T) {
+	header := http.Header{}
+	header.Add("a", "x")
+	header2 := http.Header{}
+	header2.Add("b", "x")
+	arguments := [][]string{
+		{"text/html;charset=utf-8"},
+		{"text/html;charset=utf-8;charset=utf-1;serkpodks485re&*^&^%&&%*"},
+		{"text;charset=utf-8"},
+		{"text/plain;charset=utf-8"},
+		{"text/html;charset=utf-82"},
+		{"text/html"},
+		{"text"},
+		{"375^^&87878"},
+		{""},
+	}
+	var args []interface{}
+	var profiles []ValueProfile
+	var piles []ValuePile
+	var configs []ValueConfig
+	for i := 0; i < 10; i++ {
+		profiles = append(profiles, new(MediaTypeProfile))
+		piles = append(piles, new(MediaTypePile))
+		configs = append(configs, new(MediaTypeConfig))
+	}
+	for i := 0; i < len(arguments); i++ {
+		args = append(args, arguments[i])
+	}
+	ValueTests_All(t, profiles, piles, configs, args...)
+}

--- a/pkg/apis/wsecurity/v1alpha1/keyval.go
+++ b/pkg/apis/wsecurity/v1alpha1/keyval.go
@@ -1,0 +1,213 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+//////////////////// KeyValProfile ////////////////
+
+// Exposes ValueProfile interface
+type KeyValProfile map[string]*SimpleValProfile
+
+// Profile a generic map of key vals
+func (profile *KeyValProfile) profileI(args ...interface{}) {
+	switch v := args[0].(type) {
+	case map[string]string:
+		profile.ProfileMapString(v)
+	case map[string][]string:
+		profile.ProfileMapStringSlice(v)
+	default:
+		panic("Unsupported type in KeyValProfile")
+	}
+
+}
+
+func (profile *KeyValProfile) ProfileMapString(keyValMap map[string]string) {
+	*profile = nil
+	if len(keyValMap) == 0 { // no keys
+		*profile = nil
+		return
+	}
+	*profile = make(map[string]*SimpleValProfile, len(keyValMap))
+	for k, v := range keyValMap {
+		// Profile the concatenated value
+		(*profile)[k] = new(SimpleValProfile)
+		(*profile)[k].Profile(v)
+	}
+}
+
+func (profile *KeyValProfile) ProfileMapStringSlice(keyValMap map[string][]string) {
+	*profile = nil
+	if len(keyValMap) == 0 { // no keys
+		*profile = nil
+		return
+	}
+	*profile = make(map[string]*SimpleValProfile, len(keyValMap))
+	for k, v := range keyValMap {
+		// Concatenate all strings into one value
+		// Appropriate for evaluating []string where order should be also preserved
+		val := strings.Join(v, " ")
+
+		// Profile the concatenated value
+		(*profile)[k] = new(SimpleValProfile)
+		(*profile)[k].Profile(val)
+	}
+}
+
+//////////////////// KeyValPile ////////////////
+
+// Exposes ValuePile interface
+type KeyValPile map[string]*SimpleValPile
+
+func (pile *KeyValPile) addI(valProfile ValueProfile) {
+	pile.Add(valProfile.(*KeyValProfile))
+}
+
+func (pile *KeyValPile) Add(profile *KeyValProfile) {
+	if *pile == nil {
+		*pile = make(map[string]*SimpleValPile, 16)
+	}
+	for key, v := range *profile {
+		svp, exists := (*pile)[key]
+		if !exists {
+			svp = new(SimpleValPile)
+			(*pile)[key] = svp
+		}
+		svp.Add(v)
+	}
+}
+
+func (pile *KeyValPile) Clear() {
+	*pile = nil
+}
+
+func (pile *KeyValPile) mergeI(otherValPile ValuePile) {
+	pile.Merge(otherValPile.(*KeyValPile))
+}
+
+func (pile *KeyValPile) Merge(otherPile *KeyValPile) {
+	if otherPile == nil {
+		return
+	}
+	if *pile == nil {
+		*pile = *otherPile
+		return
+	}
+	for key, val := range *otherPile {
+		if myVal, exists := (*pile)[key]; exists {
+			myVal.Merge(val)
+		} else {
+			(*pile)[key] = val
+		}
+	}
+}
+
+//////////////////// KeyValConfig ////////////////
+
+// Exposes ValueConfig interface
+type KeyValConfig struct {
+	Vals          map[string]*SimpleValConfig `json:"vals"`          // Profile the value of whitelisted keys
+	OtherVals     *SimpleValConfig            `json:"otherVals"`     // Profile the values of other keys
+	OtherKeynames *SimpleValConfig            `json:"otherKeynames"` // Profile the keynames of other keys
+}
+
+func (config *KeyValConfig) decideI(valProfile ValueProfile) string {
+	return config.Decide(valProfile.(*KeyValProfile))
+}
+
+func (config *KeyValConfig) Decide(profile *KeyValProfile) string {
+	if profile == nil {
+		return ""
+	}
+
+	// For each key-val, decide
+	for k, v := range *profile {
+		// Decide based on a known keys
+		if config.Vals != nil && config.Vals[k] != nil {
+			if ret := config.Vals[k].Decide(v); ret != "" {
+				return fmt.Sprintf("Known Key %s: %s", k, ret)
+			}
+			continue
+		}
+		// Decide based on unknown key...
+		if config.OtherKeynames == nil || config.OtherVals == nil {
+			return fmt.Sprintf("Key %s is not known", k)
+		}
+		// Cosnider the keyname
+		var keyname SimpleValProfile
+		keyname.Profile(k)
+		if ret := config.OtherKeynames.Decide(&keyname); ret != "" {
+			return fmt.Sprintf("Other keyname %s: %s", k, ret)
+		}
+		// Cosnider the key value
+		if ret := config.OtherVals.Decide(v); ret != "" {
+			return fmt.Sprintf("Other keyname %s: %s", k, ret)
+		}
+		continue
+	}
+	return ""
+}
+
+// Learn implementation currently is not optimized for a large number of keys
+// Future: When the number of keys grow, Learn may reduce the number of known keys by
+// aggregating all known keys which have common low security fingerprint into
+// OtherKeynames and OtherVals
+func (config *KeyValConfig) learnI(valPile ValuePile) {
+	config.Learn(valPile.(*KeyValPile))
+}
+
+func (config *KeyValConfig) Learn(pile *KeyValPile) {
+	config.OtherVals = nil
+	config.OtherKeynames = nil
+
+	if pile == nil {
+		config.Vals = nil
+		return
+	}
+
+	// learn known keys
+	config.Vals = make(map[string]*SimpleValConfig, len(*pile))
+	for k, v := range *pile {
+		svc := new(SimpleValConfig)
+		svc.Learn(v)
+		config.Vals[k] = svc
+	}
+}
+
+func (config *KeyValConfig) fuseI(otherValConfig ValueConfig) {
+	config.Fuse(otherValConfig.(*KeyValConfig))
+}
+
+func (config *KeyValConfig) Fuse(otherConfig *KeyValConfig) {
+	if otherConfig == nil {
+		return
+	}
+	if config.Vals == nil {
+		config.Vals = otherConfig.Vals
+	} else {
+		// fuse known keys
+		for k, v := range otherConfig.Vals {
+			svc, exists := config.Vals[k]
+			if exists {
+				svc.Fuse(v)
+			} else {
+				config.Vals[k] = v
+			}
+		}
+	}
+
+	// fuse keynames of unknown keys
+	if config.OtherKeynames == nil {
+		config.OtherKeynames = otherConfig.OtherKeynames
+	} else {
+		config.OtherKeynames.Fuse(otherConfig.OtherKeynames)
+	}
+
+	// fuse key values of unknown keys
+	if config.OtherVals == nil {
+		config.OtherVals = otherConfig.OtherVals
+	} else {
+		config.OtherVals.Fuse(otherConfig.OtherVals)
+	}
+}

--- a/pkg/apis/wsecurity/v1alpha1/keyval.go
+++ b/pkg/apis/wsecurity/v1alpha1/keyval.go
@@ -107,7 +107,7 @@ func (pile *KeyValPile) Merge(otherPile *KeyValPile) {
 
 // Exposes ValueConfig interface
 type KeyValConfig struct {
-	Vals          map[string]*SimpleValConfig `json:"vals"`          // Profile the value of whitelisted keys
+	Vals          map[string]*SimpleValConfig `json:"vals"`          // Profile the value of known keys
 	OtherVals     *SimpleValConfig            `json:"otherVals"`     // Profile the values of other keys
 	OtherKeynames *SimpleValConfig            `json:"otherKeynames"` // Profile the keynames of other keys
 }

--- a/pkg/apis/wsecurity/v1alpha1/keyval_test.go
+++ b/pkg/apis/wsecurity/v1alpha1/keyval_test.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestSimpleVal_V1(t *testing.T) {
+	arguments := [][]map[string][]string{
+		{{"a": {"abc"}}},
+		{{"a": {"123abc"}, "b": {"12"}}},
+		{{"a": {"abcd"}}},
+		{{"ex": {"abc"}}},
+		{{"dfods": {"sdf;jsdfojssdfsdfsdlfosjf2390rj09uf"}}},
+		{{"a*(Y((H(H&&^%&": {"^&U%&&^GTT*YHOIJMOI"}}},
+	}
+	var args []interface{}
+	var profiles []ValueProfile
+	var piles []ValuePile
+	var configs []ValueConfig
+	for i := 0; i < 10; i++ {
+		profiles = append(profiles, new(KeyValProfile))
+		piles = append(piles, new(KeyValPile))
+		configs = append(configs, new(KeyValConfig))
+	}
+	for i := 0; i < len(arguments); i++ {
+		args = append(args, arguments[i])
+	}
+	ValueTests_All(t, profiles, piles, configs, args...)
+}

--- a/pkg/apis/wsecurity/v1alpha1/queryString.go
+++ b/pkg/apis/wsecurity/v1alpha1/queryString.go
@@ -1,0 +1,92 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"net/url"
+)
+
+//////////////////// QueryProfile ////////////////
+
+// Exposes ValueProfile interface
+type QueryProfile struct {
+	Kv KeyValProfile `json:"kv"`
+}
+
+func (profile *QueryProfile) profileI(args ...interface{}) {
+	profile.Profile(args[0].(url.Values))
+}
+
+func (profile *QueryProfile) Profile(values url.Values) {
+	profile.Kv.ProfileMapStringSlice(values)
+}
+
+//////////////////// QueryPile ////////////////
+
+// Exposes ValuePile interface
+type QueryPile struct {
+	Kv *KeyValPile `json:"kv"`
+}
+
+func (pile *QueryPile) addI(valProfile ValueProfile) {
+	pile.Add(valProfile.(*QueryProfile))
+}
+
+func (pile *QueryPile) Add(profile *QueryProfile) {
+	if pile.Kv == nil {
+		pile.Kv = new(KeyValPile)
+	}
+	pile.Kv.Add(&profile.Kv)
+}
+
+func (pile *QueryPile) mergeI(otherValPile ValuePile) {
+	pile.Merge(otherValPile.(*QueryPile))
+}
+
+func (pile *QueryPile) Merge(otherPile *QueryPile) {
+	if pile.Kv == nil {
+		pile.Kv = new(KeyValPile)
+	}
+	pile.Kv.Merge(otherPile.Kv)
+}
+
+func (pile *QueryPile) Clear() {
+	pile.Kv = new(KeyValPile)
+	if pile.Kv != nil {
+		pile.Kv.Clear()
+	}
+}
+
+//////////////////// QueryConfig ////////////////
+
+// Exposes ValueConfig interface
+type QueryConfig struct {
+	Kv KeyValConfig `json:"kv"`
+}
+
+func (config *QueryConfig) decideI(valProfile ValueProfile) string {
+	return config.Decide(valProfile.(*QueryProfile))
+}
+
+func (config *QueryConfig) Decide(profile *QueryProfile) string {
+	str := config.Kv.Decide(&profile.Kv)
+	if str == "" {
+		return str
+	}
+	return fmt.Sprintf("KeyVal: %s", str)
+}
+
+func (config *QueryConfig) learnI(valPile ValuePile) {
+	config.Learn(valPile.(*QueryPile))
+}
+
+func (config *QueryConfig) Learn(pile *QueryPile) {
+	config.Kv.Learn(pile.Kv)
+}
+
+func (config *QueryConfig) fuseI(otherValConfig ValueConfig) {
+	config.Fuse(otherValConfig.(*QueryConfig))
+}
+
+func (config *QueryConfig) Fuse(otherConfig *QueryConfig) {
+	config.Kv.Fuse(&otherConfig.Kv)
+}

--- a/pkg/apis/wsecurity/v1alpha1/queryString_test.go
+++ b/pkg/apis/wsecurity/v1alpha1/queryString_test.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestQueryString_V1(t *testing.T) {
+	arguments := [][]url.Values{
+		{{"a": {"abc"}}},
+		{{"a": {"123abc"}, "b": {"12"}}},
+		{{"a": {"abcd"}}},
+		{{"ex": {"abc"}}},
+		{{"dfods": {"sdf;jsdfojssdfsdfsdlfosjf2390rj09uf"}}},
+		{{"a*(Y((H(H&&^%&": {"^&U%&&^GTT*YHOIJMOI"}}},
+	}
+	var args []interface{}
+	var profiles []ValueProfile
+	var piles []ValuePile
+	var configs []ValueConfig
+	for i := 0; i < 10; i++ {
+		profiles = append(profiles, new(QueryProfile))
+		piles = append(piles, new(QueryPile))
+		configs = append(configs, new(QueryConfig))
+	}
+	for i := 0; i < len(arguments); i++ {
+		args = append(args, arguments[i])
+	}
+	ValueTests_All(t, profiles, piles, configs, args...)
+}

--- a/pkg/apis/wsecurity/v1alpha1/url.go
+++ b/pkg/apis/wsecurity/v1alpha1/url.go
@@ -1,0 +1,112 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+//////////////////// UrlProfile ////////////////
+
+// Exposes ValueProfile interface
+type UrlProfile struct {
+	Val      SimpleValProfile `json:"val"`
+	Segments CountProfile     `json:"segments"`
+}
+
+func (profile *UrlProfile) profileI(args ...interface{}) {
+	profile.Profile(args[0].(string))
+}
+
+func (profile *UrlProfile) Profile(path string) {
+	segments := strings.Split(path, "/")
+	numSegments := len(segments)
+	if (numSegments > 0) && segments[0] == "" {
+		segments = segments[1:]
+		numSegments--
+	}
+	if (numSegments > 0) && segments[numSegments-1] == "" {
+		numSegments--
+		segments = segments[:numSegments]
+
+	}
+	cleanPath := strings.Join(segments, "")
+	//profile.Val = new(SimpleValProfile)
+	profile.Val.Profile(cleanPath)
+
+	if numSegments > 0xFF {
+		numSegments = 0xFF
+	}
+	profile.Segments.Profile(uint8(numSegments))
+}
+
+//////////////////// UrlPile ////////////////
+
+// Exposes ValuePile interface
+type UrlPile struct {
+	Val      SimpleValPile `json:"val"`
+	Segments CountPile     `json:"segments"`
+}
+
+func (pile *UrlPile) addI(valProfile ValueProfile) {
+	pile.Add(valProfile.(*UrlProfile))
+}
+
+func (pile *UrlPile) Add(profile *UrlProfile) {
+	pile.Segments.Add(profile.Segments)
+	pile.Val.Add(&profile.Val)
+}
+
+func (pile *UrlPile) Clear() {
+	pile.Segments.Clear()
+	pile.Val.Clear()
+}
+
+func (pile *UrlPile) mergeI(otherValPile ValuePile) {
+	pile.Merge(otherValPile.(*UrlPile))
+}
+
+func (pile *UrlPile) Merge(otherPile *UrlPile) {
+	pile.Segments.Merge(otherPile.Segments)
+	pile.Val.Merge(&otherPile.Val)
+}
+
+//////////////////// UrlConfig ////////////////
+
+// Exposes ValueConfig interface
+type UrlConfig struct {
+	Val      SimpleValConfig `json:"val"`
+	Segments CountConfig     `json:"segments"`
+}
+
+func (config *UrlConfig) Decide(profile *UrlProfile) string {
+	if str := config.Segments.Decide(profile.Segments); str != "" {
+		return fmt.Sprintf("Segmengs: %s", str)
+	}
+
+	if str := config.Val.Decide(&profile.Val); str != "" {
+		return fmt.Sprintf("KeyVal: %s", str)
+	}
+	return ""
+}
+
+func (config *UrlConfig) learnI(valPile ValuePile) {
+	config.Learn(valPile.(*UrlPile))
+}
+
+func (config *UrlConfig) Learn(pile *UrlPile) {
+	config.Segments.Learn(pile.Segments)
+	config.Val.Learn(&pile.Val)
+}
+
+func (config *UrlConfig) fuseI(otherValConfig ValueConfig) {
+	config.Fuse(otherValConfig.(*UrlConfig))
+}
+
+func (config *UrlConfig) Fuse(otherConfig *UrlConfig) {
+	config.Segments.Fuse(otherConfig.Segments)
+	config.Val.Fuse(&otherConfig.Val)
+}
+
+func (config *UrlConfig) decideI(valProfile ValueProfile) string {
+	return config.Decide(valProfile.(*UrlProfile))
+}

--- a/pkg/apis/wsecurity/v1alpha1/url_test.go
+++ b/pkg/apis/wsecurity/v1alpha1/url_test.go
@@ -1,0 +1,27 @@
+package v1alpha1
+
+import "testing"
+
+func TestUrl_V1(t *testing.T) {
+	arguments := [][]string{
+		{"abc/def/file.html"},
+		{"CDE"},
+		{"abc/234/fil^e.ht%ml"},
+		{""},
+		{"FKJSDNFKJSHDFKJSDFKJSDKJ"},
+		{"$$"},
+	}
+	var args []interface{}
+	var profiles []ValueProfile
+	var piles []ValuePile
+	var configs []ValueConfig
+	for i := 0; i < 10; i++ {
+		profiles = append(profiles, new(UrlProfile))
+		piles = append(piles, new(UrlPile))
+		configs = append(configs, new(UrlConfig))
+	}
+	for i := 0; i < len(arguments); i++ {
+		args = append(args, arguments[i])
+	}
+	ValueTests_All(t, profiles, piles, configs, args...)
+}


### PR DESCRIPTION
This PR includes another fundamental dataType often used by Guard - the KeyVal. 

KeyVal implements two methods for profiling key-value data: 
 - For known keys, it implements a map[string]SimpleVal  
  - for unknown keys, it implements a SimpleVal to capture all unknown keys and a SImpleVal to capture all values of such keys. 
The second option is currently used for manual configuration only since the current implementation learner uses only Known Keys - this should change in the future to better control the number of known keys. 
  
Additionally, this PR includes:
-  HttpHeaders and QuesryString - both based on KeyVal
- URL - based on SimpleVal and Count
- HttpMediaType - based on a Set of Types and a KeyVal of parameters (a compromise that can be improved in the future)
