### PR TITLE
fix pod alerts (take 2)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -117,7 +117,6 @@ jobs:
     - name: Wait for Ready2
       run: |
         echo Waiting for Pods to become ready.
-        kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
         # For debugging.
         kubectl get pods --all-namespaces

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Wait for Ready
       run: |
-        echo Waiting for Pods to become ready.
+        echo Waiting for Pods to become ready.git 
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
         # For debugging.
@@ -113,6 +113,14 @@ jobs:
            --annotation qpoption.knative.dev/guard-activate=enable
         URL=`kn service list|head -2|tail -1|awk '{print $2}'`   
         echo "SERVICE_URL=$URL" >> $GITHUB_ENV
+
+    - name: Wait for Ready2
+      run: |
+        echo Waiting for Pods to become ready.git 
+        kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
+        kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
+        # For debugging.
+        kubectl get pods --all-namespaces
 
     - name: Run e2e Tests With TLS
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -71,6 +71,7 @@ jobs:
       run: |
         echo Waiting for Pods to become ready.
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
+        kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
         # For debugging.
         kubectl get pods --all-namespaces
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Wait for Ready
       run: |
-        echo Waiting for Pods to become ready.git 
+        echo Waiting for Pods to become ready.
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
         # For debugging.
@@ -116,7 +116,7 @@ jobs:
 
     - name: Wait for Ready2
       run: |
-        echo Waiting for Pods to become ready.git 
+        echo Waiting for Pods to become ready.
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app.kubernetes.io/name=knative-serving"
         kubectl wait pod --timeout 300s --for=condition=Ready -n knative-serving -l "app=guard-service"
         # For debugging.

--- a/pkg/apis/guard/v1alpha1/pod.go
+++ b/pkg/apis/guard/v1alpha1/pod.go
@@ -115,10 +115,17 @@ func IpNetFromProc(protocol string) (ips []net.IP) {
 		return
 	}
 
+	ipMap := make(map[string]bool)
 	ips = make([]net.IP, 0)
+
 	ip, data := nextRemoteIp(data)
 	for data != nil {
-		ips = append(ips, ip)
+		ipStr := ip.String()
+		if _, ok := ipMap[ipStr]; !ok {
+			// New IP address
+			ipMap[ipStr] = true
+			ips = append(ips, ip)
+		}
 		ip, data = nextRemoteIp(data)
 	}
 	return ips

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -78,6 +78,7 @@ func (p *plug) ApproveRequest(req *http.Request) (*http.Request, error) {
 
 	if p.gateState.shouldBlock() && (s.hasAlert() || p.gateState.hasAlert()) {
 		p.gateState.addStat("BlockOnRequest")
+		pi.Log.Debugf("Request blocked")
 		cancelFunction()
 		return nil, errSecurity
 	}
@@ -108,7 +109,7 @@ func (p *plug) ApproveResponse(req *http.Request, resp *http.Response) (*http.Re
 	s.screenEnvelop()
 	if p.gateState.shouldBlock() && (s.hasAlert() || p.gateState.hasAlert()) {
 		p.gateState.addStat("BlockOnResponse")
-		pi.Log.Debugf("*** Cancel *** during ApproveResponse")
+		pi.Log.Debugf("Response blocked")
 		s.cancel()
 		return nil, errSecurity
 	}

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -107,8 +107,9 @@ func (p *plug) ApproveResponse(req *http.Request, resp *http.Response) (*http.Re
 	s.screenResponseBody(resp)
 	s.screenEnvelop()
 	if p.gateState.shouldBlock() && (s.hasAlert() || p.gateState.hasAlert()) {
-		s.cancel()
 		p.gateState.addStat("BlockOnResponse")
+		pi.Log.Debugf("*** Cancel *** during ApproveResponse")
+		s.cancel()
 		return nil, errSecurity
 	}
 

--- a/pkg/guard-gate/session.go
+++ b/pkg/guard-gate/session.go
@@ -96,7 +96,7 @@ func (s *session) sessionEventLoop(ctx context.Context) {
 
 		// Should we alert?
 		if s.gateState.hasAlert() {
-			logAlert("Pod has an alert")
+			s.gateState.logAlert()
 			s.gateState.addStat("BlockOnPod")
 			return
 		}
@@ -133,8 +133,8 @@ func (s *session) sessionEventLoop(ctx context.Context) {
 			s.screenEnvelop()
 			s.screenPod()
 			if s.gateState.shouldBlock() && (s.hasAlert() || s.gateState.hasAlert()) {
+				pi.Log.Debugf("*** Cancel *** during sessionTicker")
 				s.cancel()
-				pi.Log.Debugf("Session Canceled")
 				return
 			}
 			pi.Log.Debugf("Session Tick")

--- a/pkg/guard-gate/session.go
+++ b/pkg/guard-gate/session.go
@@ -133,7 +133,7 @@ func (s *session) sessionEventLoop(ctx context.Context) {
 			s.screenEnvelop()
 			s.screenPod()
 			if s.gateState.shouldBlock() && (s.hasAlert() || s.gateState.hasAlert()) {
-				pi.Log.Debugf("*** Cancel *** during sessionTicker")
+				pi.Log.Debugf("Request processing canceled during sessionTicker")
 				s.cancel()
 				return
 			}

--- a/pkg/guard-gate/state.go
+++ b/pkg/guard-gate/state.go
@@ -134,8 +134,8 @@ func (gs *gateState) profileAndDecidePod() {
 			gs.alert = decision.String("Pod  -> ")
 			gs.logAlert()
 			if gs.shouldBlock() {
-				// terminate the reverse proxy
-				pi.Log.Infof("Terminating since Pod is now blocking all requests")
+				// Terminate the reverse proxy since all requests will block from now on
+				pi.Log.Infof("Terminating")
 				gs.cancelFunc()
 			}
 		}

--- a/pkg/guard-gate/state.go
+++ b/pkg/guard-gate/state.go
@@ -40,6 +40,7 @@ type gateState struct {
 	pod        spec.PodProfile         // pod profile
 	srv        *gateClient             // maintainer of the pile, include client to the guard-service & kubeApi
 	certPool   *x509.CertPool          // rootCAs
+	prevAlert  string                  // previous gate alert
 }
 
 func (gs *gateState) init(cancelFunc context.CancelFunc, monitorPod bool, guardServiceUrl string, sid string, ns string, useCm bool) {
@@ -96,7 +97,7 @@ func (gs *gateState) loadConfig() {
 	}
 	criteria.Prepare()
 	gs.criteria = criteria
-	pi.Log.Infof("Loading Guardian  - Active %t Auto %t", gs.criteria.Active, gs.ctrl.Auto)
+	pi.Log.Infof("Loading Guardian  - Active %t Auto %t Block %t", gs.criteria.Active, gs.ctrl.Auto, gs.ctrl.Block)
 }
 
 // flushPile is called periodically to send the pile to the guard-service
@@ -131,12 +132,22 @@ func (gs *gateState) profileAndDecidePod() {
 		if decision != nil {
 			gs.addStat("PodAlert")
 			gs.alert = decision.String("Pod  -> ")
-
-			logAlert(gs.alert)
-			// terminate the reverse proxy
-			gs.cancelFunc()
+			gs.logAlert()
+			if gs.shouldBlock() {
+				// terminate the reverse proxy
+				pi.Log.Infof("Terminating since Pod is now blocking all requests")
+				gs.cancelFunc()
+			}
 		}
 	}
+}
+
+func (gs *gateState) logAlert() {
+	if gs.prevAlert == gs.alert {
+		return
+	}
+	gs.prevAlert = gs.alert
+	logAlert(gs.alert)
 }
 
 // if pod is monitored, copy its profile to the session profile


### PR DESCRIPTION
This is a repeat of #136    + adds a fix to e2e tests
Due to some unexplained technical problem with the previous PR

This PR:

Fix a bug through which pod was terminated due to the detection of approaches to abnormal IP addresses even if Block is false.
Improve alert logging during the detection of abnormal IP addresses
I added review comments to explain the change and expedite review (let me know if you find this a good practice?)

To be cherrypicked

@davidhadas
