### PR TITLE
Added Prepare() in guardService, fixed wrong array treatment in Learn()

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -1,0 +1,6 @@
+# Go coding style rules adopted
+
+1. Use `x := []X_TYPE{}` when initializing an empty array - dont use `x := make(X_TYPE, 0)`
+   Think twice whenever you use `x := make(X_TYPE, n)` for `n>0`
+   Note that you just added n empty items to the array.
+   Think 10 times if you ever use/see `x := make(X_TYPE, n)` followed by `x = append (x, something)`

--- a/cmd/guard-service/main_test.go
+++ b/cmd/guard-service/main_test.go
@@ -289,7 +289,7 @@ func TestTLS_SyncHandler_MissingToken(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)
@@ -379,7 +379,7 @@ func TestTLS_SyncHandler_NotPOST(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)
@@ -422,7 +422,7 @@ func TestTLS_badUrl(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)
@@ -465,7 +465,7 @@ func TestTLS_SyncHandler_NoReqBody(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)
@@ -562,7 +562,7 @@ func TestTLS_SyncHandler_WithBadReq(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)
@@ -740,7 +740,7 @@ func TestNOTLS_SyncHandler_WithBadQuery(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	buf := make([]byte, 0)
+	buf := []byte{}
 	if reflect.DeepEqual(rr.Body, buf) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), buf)

--- a/cmd/guard-service/services.go
+++ b/cmd/guard-service/services.go
@@ -164,6 +164,11 @@ func (s *services) get(ns string, sid string, cmFlag bool) *serviceRecord {
 // set to cache
 // caller ensures that guardianSpec is never nil
 func (s *services) set(ns string, sid string, cmFlag bool, guardianSpec *spec.GuardianSpec) *serviceRecord {
+	// we have  a new guardianSpec from update() or from get()
+	if guardianSpec.Learned != nil {
+		guardianSpec.Learned.Prepare()
+	}
+
 	service := serviceKey(ns, sid, cmFlag)
 
 	s.mutex.Lock()

--- a/pkg/apis/guard/v1alpha1/pod.go
+++ b/pkg/apis/guard/v1alpha1/pod.go
@@ -116,7 +116,7 @@ func IpNetFromProc(protocol string) (ips []net.IP) {
 	}
 
 	ipMap := make(map[string]bool)
-	ips = make([]net.IP, 0)
+	ips = []net.IP{}
 
 	ip, data := nextRemoteIp(data)
 	for data != nil {

--- a/pkg/apis/guard/v1alpha1/set.go
+++ b/pkg/apis/guard/v1alpha1/set.go
@@ -143,7 +143,7 @@ func (config *SetConfig) learnI(valPile ValuePile) {
 // pile is RO and unchanged - never uses pile internal objects
 func (config *SetConfig) Learn(pile *SetPile) {
 	if config.List == nil {
-		config.List = make([]string, len(pile.List))
+		config.List = []string{}
 	}
 	if config.m == nil {
 		config.m = make(map[string]bool, len(pile.List))

--- a/pkg/apis/guard/v1alpha1/set_test.go
+++ b/pkg/apis/guard/v1alpha1/set_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestSet_STRING(t *testing.T) {
 	arguments := [][]string{
@@ -64,4 +67,54 @@ func TestSet_STRINGSLICE(t *testing.T) {
 		args = append(args, arguments[i])
 	}
 	ValueTests_All(t, profiles, piles, configs, args...)
+}
+
+func TestSet_Duplicates(t *testing.T) {
+	var profile1 SetProfile
+	var profile2 SetProfile
+	var pile1 SetPile
+	var pile2 SetPile
+	var config SetConfig
+	var config_load SetConfig
+
+	profile1.ProfileString("X")
+	profile1.ProfileString("X")
+	profile1.ProfileString("X")
+	profile1.ProfileString("X")
+	profile2.ProfileString("X")
+	profile2.ProfileString("X")
+	pile1.Add(&profile1)
+	pile2.Add(&profile2)
+	pile2.Merge(&pile1)
+	if len(pile2.List) != 1 {
+		t.Errorf("SetPile.Merge() expected 1 items found %d", len(pile2.List))
+	}
+	config.Learn(&pile2)
+	if len(config.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config.List))
+	}
+	config.Learn(&pile2)
+	if len(config.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config.List))
+	}
+	j, _ := json.Marshal(config)
+	json.Unmarshal(j, &config_load)
+	config_load.Prepare()
+	if len(config_load.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config_load.List))
+	}
+	config_load.Learn(&pile2)
+	if len(config_load.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config_load.List))
+	}
+	j, _ = json.Marshal(config)
+	json.Unmarshal(j, &config_load)
+	config_load.Prepare()
+	if len(config_load.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config_load.List))
+	}
+	config_load.Learn(&pile2)
+	if len(config_load.List) != 1 {
+		t.Errorf("SetPile.Learn() expected 1 item found %d", len(config_load.List))
+	}
 }


### PR DESCRIPTION
Fix: #155 
Missing Prepare() in the service guard resulted in duplication of set values in Set.List
Wrong array handling in set Learn() resulted in the addition of empty items to Set.List 

In view of the wrong array handling, decided on a CODING rule to reduce the use of make() on arrays
