### PR TITLE
Handling 

### DIFF
--- a/cmd/guard-service/main.go
+++ b/cmd/guard-service/main.go
@@ -197,6 +197,10 @@ func (l *learner) processSync(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if syncReq.IamCompromised {
+		l.services.deletePod(record, podname)
+	}
+
 	if syncReq.Pile != nil {
 		l.services.merge(record, syncReq.Pile)
 	}

--- a/cmd/guard-service/services.go
+++ b/cmd/guard-service/services.go
@@ -239,3 +239,7 @@ func (s *services) persist(record *serviceRecord) {
 		pi.Log.Debugf("Update KubeApi with new config %s.%s", record.ns, record.sid)
 	}
 }
+
+func (s *services) deletePod(record *serviceRecord, podname string) {
+	s.kmgr.DeletePod(record.ns, podname)
+}

--- a/cmd/guard-service/services_test.go
+++ b/cmd/guard-service/services_test.go
@@ -52,6 +52,9 @@ func (f *fakeKmgr) TokenData(token string, labels []string) (podname string, sid
 	return "mypod", "mysid", "myns", nil
 }
 
+func (f *fakeKmgr) DeletePod(ns string, podname string) {
+}
+
 func Test_serviceKey(t *testing.T) {
 	type args struct {
 		ns     string

--- a/config/resources/serviceAccount.yaml
+++ b/config/resources/serviceAccount.yaml
@@ -20,6 +20,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       - configmaps
     verbs:
       - get

--- a/pkg/apis/guard/v1alpha1/v1alpha1.go
+++ b/pkg/apis/guard/v1alpha1/v1alpha1.go
@@ -45,8 +45,9 @@ type Alert struct {
 }
 
 type SyncMessageReq struct {
-	Pile   *SessionDataPile `json:"pile"`
-	Alerts []Alert          `json:"alerts"`
+	Pile           *SessionDataPile `json:"pile"`
+	Alerts         []Alert          `json:"alerts"`
+	IamCompromised bool             `json:"compromised"`
 }
 
 type SyncMessageResp struct {

--- a/pkg/guard-gate/client_test.go
+++ b/pkg/guard-gate/client_test.go
@@ -77,6 +77,9 @@ func (f *fakeKmgr) TokenData(token string, labels []string) (podname string, sid
 	return "mypod", "mysid", "myns", nil
 }
 
+func (f *fakeKmgr) DeletePod(ns string, podname string) {
+}
+
 type fakeHttpClient struct {
 	statusCode int
 	json       []byte

--- a/pkg/guard-gate/state_test.go
+++ b/pkg/guard-gate/state_test.go
@@ -30,13 +30,9 @@ import (
 
 var gateCanceled int
 
-func fakeGateCancel() {
-	gateCanceled++
-}
-
 func fakeGateState() *gateState {
 	gs := new(gateState)
-	gs.init(fakeGateCancel, false, "myurl", "mypodname", "mysid", "myns", true)
+	gs.init(false, "myurl", "mypodname", "mysid", "myns", true)
 	bytes, _ := json.Marshal(spec.Guardian{})
 	srv, _ := fakeClient(http.StatusOK, string(bytes))
 	gs.srv = srv
@@ -199,7 +195,7 @@ func Test_gateState_init(t *testing.T) {
 			os.Setenv("ROOT_CA", tt.cert)
 			gs := new(gateState)
 			// certPool, _ := x509.SystemCertPool()
-			gs.init(fakeGateCancel, false, "myurl", "mypodname", "mysid", "myns", true)
+			gs.init(false, "myurl", "mypodname", "mysid", "myns", true)
 			// TBD will be added when we move to go 1.19
 			// if !certPool.Equal(gs.certPool) && !tt.newCA {
 			// 	 t.Errorf("expected no new cert to be added")

--- a/pkg/guard-kubemgr/guard-kubemgr.go
+++ b/pkg/guard-kubemgr/guard-kubemgr.go
@@ -50,6 +50,7 @@ type KubeMgrInterface interface {
 	GetGuardian(ns string, sid string, cm bool, autoActivate bool) *spec.GuardianSpec
 	Watch(ns string, cmFlag bool, set func(ns string, sid string, cmFlag bool, g *spec.GuardianSpec))
 	TokenData(token string, labels []string) (podname string, sid string, ns string, err error)
+	DeletePod(ns string, podname string)
 }
 
 // KubeMgr manages Guardian CRDs and Guardian CMs
@@ -113,6 +114,17 @@ func (k *KubeMgr) InitConfigs() {
 		panic(err.Error())
 	}
 	k.crdClient = crdClientSet.GuardV1alpha1()
+}
+
+// DeletePod - Deletes a Pod
+func (k *KubeMgr) DeletePod(ns string, podname string) {
+	err := k.cmClient.CoreV1().Pods(ns).Delete(context.TODO(), podname, metav1.DeleteOptions{})
+	if err != nil {
+		// can't read CRD
+		pi.Log.Infof("fail to delete pod ns %s podname %s - error %v", ns, podname, err)
+	} else {
+		pi.Log.Infof("delete pod ns %s podname %s", ns, podname)
+	}
 }
 
 // readCrd - Reads a Guardian Crd from KubeApi


### PR DESCRIPTION
Changes made include:

- Guard-gate no longer uses cancelFunction() therefore it no uses the queue context only for learning when queue exits.
- Guard-gate maintains an IamConrpomised bool flag which is true if it finds that the pod is compromised and Block=true in the guardian.ctrl
- Guard-gate sends an IamConrpomised bool flag as part of Sync Request to guard-service. 
- Guard-service deletes any pod which sends IamConrpomised=true as part of a Sync Request. 

In addition, a bug in gate-level alert logging is fixed.
