### PR TITLE
Improve Performance following pprof analysis

### DIFF
--- a/cmd/guard-service/main.go
+++ b/cmd/guard-service/main.go
@@ -69,7 +69,7 @@ func (l *learner) getToken(token string) *tokenData {
 	l.tokenMutex.Lock()
 	defer l.tokenMutex.Unlock()
 	td := l.tokens[token]
-	if ticks-td.ticks > 3600 {
+	if td != nil && ticks-td.ticks > 3600 {
 		// 60 min  - cahce out
 		delete(l.tokens, token)
 		return nil

--- a/cmd/guard-service/main_test.go
+++ b/cmd/guard-service/main_test.go
@@ -77,6 +77,7 @@ func Test_learner_mainEventLoop(t *testing.T) {
 		l := &learner{
 			services:        s,
 			pileLearnTicker: ticker,
+			tokens:          make(map[string]*tokenData),
 		}
 		for i := uint(1); i <= 10; i++ {
 			addSample(s)
@@ -203,6 +204,7 @@ func Test_NOTLS_learner_baseHandler(t *testing.T) {
 			l := &learner{
 				services:        s,
 				pileLearnTicker: ticker,
+				tokens:          make(map[string]*tokenData),
 			}
 			l.env.GuardServiceAuth = "false"
 			gotCmFlag, gotPod, gotSid, gotNs, gotErr := l.queryDataNoAuth(tt.query)
@@ -270,6 +272,7 @@ func Test_TLS_learner_baseHandler(t *testing.T) {
 			l := &learner{
 				services:        s,
 				pileLearnTicker: ticker,
+				tokens:          make(map[string]*tokenData),
 			}
 			l.env.GuardServiceAuth = "anything"
 			gotCmFlag, gotErr := l.queryDataAuth(tt.query)
@@ -302,6 +305,7 @@ func TestTLS_SyncHandler_MissingToken(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -339,6 +343,7 @@ func TestNOTLS_SyncHandler_main(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 
 	l.env.GuardServiceAuth = "false"
@@ -363,6 +368,7 @@ func TestTLS_SyncHandler_main(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 
 	l.env.GuardServiceAuth = "anything"
@@ -387,6 +393,7 @@ func TestTLS_SyncHandler_NotPOST(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -430,6 +437,7 @@ func TestTLS_badUrl(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -473,6 +481,7 @@ func TestTLS_SyncHandler_NoReqBody(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -516,6 +525,7 @@ func TestTLS_SyncHandler_EmptyPileAndAlert(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -567,6 +577,7 @@ func TestTLS_SyncHandler_WithBadReq(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -613,6 +624,7 @@ func TestTLS_SyncHandler_WithGoodReq(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "anything"
 
@@ -678,6 +690,7 @@ func TestNOTLS_SyncHandler_WithGoodReq(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "false"
 
@@ -745,6 +758,7 @@ func TestNOTLS_SyncHandler_WithBadQuery(t *testing.T) {
 	l := &learner{
 		services:        s,
 		pileLearnTicker: ticker,
+		tokens:          make(map[string]*tokenData),
 	}
 	l.env.GuardServiceAuth = "false"
 
@@ -833,6 +847,7 @@ func Test_learner_authenticate(t *testing.T) {
 			l := &learner{
 				services:        s,
 				pileLearnTicker: ticker,
+				tokens:          make(map[string]*tokenData),
 			}
 			l.env.GuardServiceAuth = "anything"
 

--- a/cmd/guard-service/main_test.go
+++ b/cmd/guard-service/main_test.go
@@ -59,26 +59,34 @@ func testStatus(txt string, s *services, t *testing.T, pile uint32, guardian uin
 	}
 }
 
+func testLearner() *learner {
+	s := new(services)
+	s.cache = make(map[string]*serviceRecord, 64)
+	s.namespaces = make(map[string]bool, 4)
+	s.kmgr = new(fakeKmgr)
+
+	ticker := utils.NewTicker(100000)
+	ticker2 := utils.NewTicker(100000)
+	l := &learner{
+		services:          s,
+		pileLearnTicker:   ticker,
+		chacheTokenTicker: ticker2,
+		tokens:            make(map[string]*tokenData),
+	}
+	return l
+}
+
 func Test_learner_mainEventLoop(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		quit := make(chan bool, 1)
 		flushed := make(chan bool, 1)
 
 		// services
-		s := new(services)
-		s.cache = make(map[string]*serviceRecord, 64)
-		s.namespaces = make(map[string]bool, 4)
-		s.kmgr = new(fakeKmgr)
-
-		ticker := utils.NewTicker(100000)
-		ticker.Parse("", 100000)
-		ticker.Start()
+		l := testLearner()
+		l.pileLearnTicker.Start()
 		kill := make(chan os.Signal, 1)
-		l := &learner{
-			services:        s,
-			pileLearnTicker: ticker,
-			tokens:          make(map[string]*tokenData),
-		}
+		s := l.services
+
 		for i := uint(1); i <= 10; i++ {
 			addSample(s)
 			// 10% rule - immediate learning
@@ -193,19 +201,8 @@ func Test_NOTLS_learner_baseHandler(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// services
-		s := new(services)
-		s.cache = make(map[string]*serviceRecord, 64)
-		s.namespaces = make(map[string]bool, 4)
-		s.kmgr = new(fakeKmgr)
-
-		ticker := utils.NewTicker(100000)
 		t.Run(tt.name, func(t *testing.T) {
-			l := &learner{
-				services:        s,
-				pileLearnTicker: ticker,
-				tokens:          make(map[string]*tokenData),
-			}
+			l := testLearner()
 			l.env.GuardServiceAuth = "false"
 			gotCmFlag, gotPod, gotSid, gotNs, gotErr := l.queryDataNoAuth(tt.query)
 			if tt.wantErr == (gotErr == nil) {
@@ -261,19 +258,8 @@ func Test_TLS_learner_baseHandler(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// services
-		s := new(services)
-		s.cache = make(map[string]*serviceRecord, 64)
-		s.namespaces = make(map[string]bool, 4)
-		s.kmgr = new(fakeKmgr)
-
-		ticker := utils.NewTicker(100000)
 		t.Run(tt.name, func(t *testing.T) {
-			l := &learner{
-				services:        s,
-				pileLearnTicker: ticker,
-				tokens:          make(map[string]*tokenData),
-			}
+			l := testLearner()
 			l.env.GuardServiceAuth = "anything"
 			gotCmFlag, gotErr := l.queryDataAuth(tt.query)
 			if tt.wantErr == (gotErr == nil) {
@@ -296,17 +282,7 @@ func TestTLS_SyncHandler_MissingToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
@@ -334,17 +310,7 @@ func TestTLS_SyncHandler_MissingToken(t *testing.T) {
 }
 
 func TestNOTLS_SyncHandler_main(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 
 	l.env.GuardServiceAuth = "false"
 	l.env.GuardServiceTls = "false"
@@ -359,17 +325,7 @@ func TestNOTLS_SyncHandler_main(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_main(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 
 	l.env.GuardServiceAuth = "anything"
 	l.env.GuardServiceTls = "anything"
@@ -384,17 +340,7 @@ func TestTLS_SyncHandler_main(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_NotPOST(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
@@ -428,17 +374,7 @@ func TestTLS_SyncHandler_NotPOST(t *testing.T) {
 }
 
 func TestTLS_badUrl(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
@@ -472,17 +408,7 @@ func TestTLS_badUrl(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_NoReqBody(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
@@ -516,20 +442,10 @@ func TestTLS_SyncHandler_NoReqBody(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_EmptyPileAndAlert(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
-	record := s.get("ns", "sid9", false)
+	record := l.services.get("ns", "sid9", false)
 	postBody, _ := json.Marshal(&record.pile)
 	reqBody := bytes.NewBuffer(postBody)
 
@@ -568,17 +484,7 @@ func TestTLS_SyncHandler_EmptyPileAndAlert(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_WithBadReq(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	postBody, _ := json.Marshal("xx")
@@ -615,17 +521,7 @@ func TestTLS_SyncHandler_WithBadReq(t *testing.T) {
 }
 
 func TestTLS_SyncHandler_WithGoodReq(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "anything"
 
 	var syncReq spec.SyncMessageReq
@@ -680,18 +576,9 @@ func TestTLS_SyncHandler_WithGoodReq(t *testing.T) {
 			rr.Body.String(), string(buf))
 	}
 }
-func TestNOTLS_SyncHandler_WithGoodReq(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
 
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+func TestNOTLS_SyncHandler_WithGoodReq(t *testing.T) {
+	l := testLearner()
 	l.env.GuardServiceAuth = "false"
 
 	var syncReq spec.SyncMessageReq
@@ -749,17 +636,7 @@ func TestNOTLS_SyncHandler_WithGoodReq(t *testing.T) {
 }
 
 func TestNOTLS_SyncHandler_WithBadQuery(t *testing.T) {
-	s := new(services)
-	s.cache = make(map[string]*serviceRecord, 64)
-	s.namespaces = make(map[string]bool, 4)
-	s.kmgr = new(fakeKmgr)
-
-	ticker := utils.NewTicker(100000)
-	l := &learner{
-		services:        s,
-		pileLearnTicker: ticker,
-		tokens:          make(map[string]*tokenData),
-	}
+	l := testLearner()
 	l.env.GuardServiceAuth = "false"
 
 	var syncReq spec.SyncMessageReq
@@ -838,17 +715,7 @@ func Test_learner_authenticate(t *testing.T) {
 			}
 			req.Header.Add("Authorization", tt.authorization)
 
-			s := new(services)
-			s.cache = make(map[string]*serviceRecord, 64)
-			s.namespaces = make(map[string]bool, 4)
-			s.kmgr = new(fakeKmgr)
-
-			ticker := utils.NewTicker(100000)
-			l := &learner{
-				services:        s,
-				pileLearnTicker: ticker,
-				tokens:          make(map[string]*tokenData),
-			}
+			l := testLearner()
 			l.env.GuardServiceAuth = "anything"
 
 			gotPodname, gotSid, gotNs, err := l.authenticate(req)

--- a/pkg/apis/guard/v1alpha1/envelop.go
+++ b/pkg/apis/guard/v1alpha1/envelop.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"time"
-)
-
 // Envelop dataType maintains session data that is collected beyond Req, ReqBody, Resp and RespBody
 
 //////////////////// EnvelopProfile ////////////////
@@ -31,15 +27,15 @@ type EnvelopProfile struct {
 }
 
 func (profile *EnvelopProfile) profileI(args ...interface{}) {
-	profile.Profile(args[0].(time.Time), args[1].(time.Time), args[2].(time.Time))
+	profile.Profile(args[0].(int64), args[1].(int64), args[2].(int64))
 }
 
-func (profile *EnvelopProfile) Profile(reqTime time.Time, respTime time.Time, endTime time.Time) {
+func (profile *EnvelopProfile) Profile(reqTime int64, respTime int64, endTime int64) {
 
-	completionTime := endTime.Sub(reqTime).Seconds()
+	completionTime := endTime - reqTime
 	profile.CompletionTime.Profile(uint(completionTime))
 
-	responseTime := respTime.Sub(reqTime).Seconds()
+	responseTime := respTime - reqTime
 	profile.ResponseTime.Profile(uint(responseTime))
 }
 

--- a/pkg/apis/guard/v1alpha1/envelop_test.go
+++ b/pkg/apis/guard/v1alpha1/envelop_test.go
@@ -30,6 +30,7 @@ func TestEnvelop_V1(t *testing.T) {
 		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
 		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
 		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
+		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
 	}
 	var args []interface{}
 	var profiles []ValueProfile

--- a/pkg/apis/guard/v1alpha1/envelop_test.go
+++ b/pkg/apis/guard/v1alpha1/envelop_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestEnvelop_V1(t *testing.T) {
 	interval, _ := time.ParseDuration("2h")
-	arguments := [][]time.Time{
-		{time.Now(), time.Now(), time.Now()},
-		{time.Now(), time.Now().Add(interval), time.Now().Add(interval)},
-		{time.Now(), time.Now().Add(interval), time.Now().Add(interval)},
-		{time.Now(), time.Now(), time.Now()},
-		{time.Now(), time.Now(), time.Now()},
-		{time.Now(), time.Now(), time.Now()},
+	arguments := [][]int64{
+		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
+		{time.Now().Unix(), time.Now().Add(interval).Unix(), time.Now().Add(interval).Unix()},
+		{time.Now().Unix(), time.Now().Add(interval).Unix(), time.Now().Add(interval).Unix()},
+		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
+		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
+		{time.Now().Unix(), time.Now().Unix(), time.Now().Unix()},
 	}
 	var args []interface{}
 	var profiles []ValueProfile

--- a/pkg/apis/guard/v1alpha1/sessionData.go
+++ b/pkg/apis/guard/v1alpha1/sessionData.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"net"
 	"net/http"
-	"time"
 )
 
 //////////////////// SessionDataProfile ////////////////
@@ -40,13 +39,13 @@ func (profile *SessionDataProfile) profileI(args ...interface{}) {
 	resp := args[2].(*http.Response)
 	reqData := args[3]
 	respData := args[4]
-	reqTime := args[5].(time.Time)
-	respTime := args[6].(time.Time)
-	endTime := args[7].(time.Time)
+	reqTime := args[5].(int64)
+	respTime := args[6].(int64)
+	endTime := args[7].(int64)
 	profile.Profile(req, cip, resp, reqData, respData, reqTime, respTime, endTime)
 }
 
-func (profile *SessionDataProfile) Profile(req *http.Request, cip net.IP, resp *http.Response, reqData interface{}, respData interface{}, reqTime time.Time, respTime time.Time, endTime time.Time) {
+func (profile *SessionDataProfile) Profile(req *http.Request, cip net.IP, resp *http.Response, reqData interface{}, respData interface{}, reqTime int64, respTime int64, endTime int64) {
 	// never used
 	profile.Req.Profile(req, cip)
 	profile.Resp.Profile(resp)

--- a/pkg/apis/guard/v1alpha1/sessionData_test.go
+++ b/pkg/apis/guard/v1alpha1/sessionData_test.go
@@ -107,9 +107,9 @@ func TestSessionData_Decide(t *testing.T) {
 		resp      http.Response
 		reqData   interface{}
 		respData  interface{}
-		reqTime   time.Time
-		respTime  time.Time
-		endTime   time.Time
+		reqTime   int64
+		respTime  int64
+		endTime   int64
 	}
 	tests := []struct {
 		name     string
@@ -126,7 +126,7 @@ func TestSessionData_Decide(t *testing.T) {
 				reqMethod: "Post",
 				reqTarget: "/abc2/א",
 				reqData:   "abc",
-				reqTime:   time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+				reqTime:   1000,
 			},
 			decision: "[Envelop:[CompletionTime:[Limit out of Range: 255,],ResponseTime:[Limit out of Range: 255,],],Req:[MediaType:[Type:[Unexpected key none in Set,],],Method:[Unexpected key Post in Set,],Proto:[Unexpected key HTTP/1.1 in Set,],Url:[Segments:[Value 2 Not Allowed!,],Val:[Digits:[Limit out of Range: 1,],Letters:[Limit out of Range: 3,],Sequences:[Limit out of Range: 3,],Unicode Blocks:[Unexpected Flags in FlagSlice 400 on Element 0,],Unicodes:[Limit out of Range: 1,],],],],ReqBody:[Structured Body not allowed,],Resp:[MediaType:[Type:[Unexpected key none in Set,],],],RespBody:[Structured Body not allowed,],]",
 		},

--- a/pkg/apis/guard/v1alpha1/sessionData_test.go
+++ b/pkg/apis/guard/v1alpha1/sessionData_test.go
@@ -42,13 +42,14 @@ func TestSessionData(t *testing.T) {
 
 	cip := net.IPv4(1, 2, 3, 5)
 	cip2 := net.IPv4(1, 22, 3, 5)
+	now := time.Now().Unix()
 	arguments := [][]interface{}{
-		{req, cip, resp, nil, nil, time.Now(), time.Now(), time.Now()},
-		{req2, cip2, resp2, nil, nil, time.Now(), time.Now(), time.Now()},
-		{req2, cip, resp2, nil, nil, time.Now(), time.Now(), time.Now()},
-		{req, cip, resp2, nil, nil, time.Now(), time.Now(), time.Now()},
-		{req, cip, resp2, nil, nil, time.Now(), time.Now(), time.Now()},
-		{req, cip, resp2, nil, nil, time.Now(), time.Now(), time.Now()},
+		{req, cip, resp, nil, nil, now, now, now},
+		{req2, cip2, resp2, nil, nil, now, now, now},
+		{req2, cip, resp2, nil, nil, now, now, now},
+		{req, cip, resp2, nil, nil, now, now, now},
+		{req, cip, resp2, nil, nil, now, now, now},
+		{req, cip, resp2, nil, nil, now, now, now},
 	}
 	var args []interface{}
 	var profiles []ValueProfile

--- a/pkg/dselect/dselect.go
+++ b/pkg/dselect/dselect.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dselect
+
+import (
+	"context"
+	"reflect"
+	"time"
+)
+
+type dSelectSrv struct {
+	ctx      context.Context
+	complete func(int64)
+	tick     func(int64)
+	tickSecs int64
+	lastTick int64
+}
+
+type DSelect struct {
+	ctx       context.Context
+	addSelect chan *dSelectSrv
+	setTick   func(int64)
+}
+
+func NewDSelect(ctx context.Context, setTick func(int64)) *DSelect {
+	ds := new(DSelect)
+	ds.ctx = ctx
+	ds.setTick = setTick
+	ds.addSelect = make(chan *dSelectSrv)
+	go ds.selects()
+	return ds
+}
+
+func (ds *DSelect) Add(ctx context.Context, tick func(int64), complete func(int64), tickSecs int64) {
+	ds.addSelect <- &dSelectSrv{
+		ctx:      ctx,
+		tick:     tick,
+		complete: complete,
+		tickSecs: tickSecs,
+	}
+}
+
+func (ds *DSelect) selects() {
+	var selectCases []reflect.SelectCase
+	var dsSrvices []*dSelectSrv
+	ticker := time.NewTicker(time.Second)
+	ticks := time.Now().Unix()
+
+	// selectCase 1 (chosen index=0)
+	selectCases = append(selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ds.ctx.Done()),
+	})
+	// selectCase 2 (chosen index=1)
+	selectCases = append(selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ds.addSelect),
+	})
+	// selectCase 3 (chosen index=2)
+	selectCases = append(selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ticker.C),
+	})
+
+	for {
+		chosen, recv, _ := reflect.Select(selectCases)
+		switch chosen {
+		case 0: // ds.ctx.Done()
+			ticker.Stop()
+			for _, dsSrv := range dsSrvices {
+				dsSrv.complete(ticks)
+			}
+			return
+		case 1: // ds.addSelect
+			dselectSrv := recv.Interface().(*dSelectSrv)
+			dsSrvices = append(dsSrvices, dselectSrv)
+			selectCases = append(selectCases, reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(dselectSrv.ctx.Done()),
+			})
+		case 2: // 1 second ticker
+			ticks = recv.Interface().(time.Time).Unix()
+			ds.setTick(ticks)
+			numServices := len(dsSrvices)
+			for index := 0; index < numServices; index++ {
+				dsSrv := dsSrvices[index]
+				if ticks > dsSrv.lastTick+dsSrv.tickSecs {
+					dsSrv.tick(ticks)
+					dsSrv.lastTick = ticks
+				}
+			}
+		default: // dsSrv[index].ctx.Done()
+			index := chosen - 3
+			dsSrv := dsSrvices[index]
+			dsSrv.complete(ticks)
+			dsSrvices = append(dsSrvices[:index], dsSrvices[index+1:]...)
+			selectCases = append(selectCases[:chosen], selectCases[chosen+1:]...)
+		}
+	}
+}

--- a/pkg/dselect/dselect_test.go
+++ b/pkg/dselect/dselect_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dselect
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+var myTestMutex sync.Mutex
+
+func myFunc(myVal *int64) func(val int64) {
+	return func(val int64) {
+		myTestMutex.Lock()
+		defer myTestMutex.Unlock()
+		*myVal = val
+	}
+}
+
+func TestNewDSelect(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		var ticks, ticks1, ticks2, complete1, complete2 int64
+		setTick := myFunc(&ticks)
+		setTick1 := myFunc(&ticks1)
+		setTick2 := myFunc(&ticks2)
+		setComplete1 := myFunc(&complete1)
+		setComplete2 := myFunc(&complete2)
+		ctxMain, cancelMain := context.WithCancel(context.Background())
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2 := context.Background()
+		ds := NewDSelect(ctxMain, setTick)
+		ds.Add(ctx1, setTick1, setComplete1, 2)
+		ds.Add(ctx2, setTick2, setComplete2, 2)
+		myTestMutex.Lock()
+		if ticks != 0 || ticks1 != 0 || ticks2 != 0 {
+			t.Errorf("ticks should be zero  - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 != 0 || complete2 != 0 {
+			t.Errorf("complete should be zero  - got instead %d %d", complete1, complete2)
+		}
+		myTestMutex.Unlock()
+		time.Sleep(time.Second + 100*time.Millisecond)
+		myTestMutex.Lock()
+		if ticks == 0 || ticks1 != ticks || ticks2 != ticks {
+			t.Errorf("ticks1 and ticks2 should be zero, but not main tick  - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 != 0 || complete2 != 0 {
+			t.Errorf("complete should be zero  - got instead %d %d", complete1, complete2)
+		}
+		myTestMutex.Unlock()
+		time.Sleep(time.Second)
+		myTestMutex.Lock()
+		if ticks == 0 || ticks1 == ticks || ticks2 != ticks1 {
+			t.Errorf("ticks1 and ticks 2 should be equal and not zero - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 != 0 || complete2 != 0 {
+			t.Errorf("ticks1 and ticks 2 should be equal and not zero - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		myTestMutex.Unlock()
+		cancel1()
+		time.Sleep(time.Second)
+		myTestMutex.Lock()
+		if ticks == 0 || ticks1 == 0 || ticks2 != ticks1 {
+			t.Errorf("ticks1 and ticks 2 should be equal and not zero - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 == 0 || complete2 != 0 {
+			t.Errorf("complete2 should, but not complete1  - got instead %d %d", complete1, complete2)
+		}
+		myTestMutex.Unlock()
+		time.Sleep(time.Second)
+		myTestMutex.Lock()
+		if ticks == 0 || ticks1 == 0 || ticks2 == ticks1 {
+			t.Errorf("ticks should be different  - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 == 0 || complete2 != 0 {
+			t.Errorf("complete2 should, but not complete1  - got instead %d %d", complete1, complete2)
+		}
+		myTestMutex.Unlock()
+		cancelMain()
+		time.Sleep(time.Second)
+		myTestMutex.Lock()
+		if ticks == 0 || ticks1 == 0 || ticks2 == ticks1 {
+			t.Errorf("ticks should be zero  - got instead %d %d %d", ticks, ticks1, ticks2)
+		}
+		if complete1 == 0 || complete2 == 0 {
+			t.Errorf("complete should not be zero  - got instead %d %d", complete1, complete2)
+		}
+		myTestMutex.Unlock()
+	})
+
+}

--- a/pkg/guard-gate/client.go
+++ b/pkg/guard-gate/client.go
@@ -248,8 +248,8 @@ func (srv *gateClient) addToPile(profile *spec.SessionDataProfile) uint32 {
 	return srv.pile.Count
 }
 
-func (srv *gateClient) syncWithServiceAndKubeApi(shouldLoad bool) *spec.GuardianSpec {
-	wsGate := srv.syncWithService(0)
+func (srv *gateClient) syncWithServiceAndKubeApi(ticks int64, shouldLoad bool) *spec.GuardianSpec {
+	wsGate := srv.syncWithService(ticks)
 	if wsGate == nil && shouldLoad {
 		// never return nil!
 		wsGate = srv.kubeMgr.GetGuardian(srv.ns, srv.sid, srv.useCm, true)

--- a/pkg/guard-gate/client_test.go
+++ b/pkg/guard-gate/client_test.go
@@ -122,7 +122,7 @@ func Test_guardClient_sync_pile(t *testing.T) {
 		srv.addAlert(decision, "Pod")
 		srv.addToPile(new(spec.SessionDataProfile))
 		srv.addToPile(new(spec.SessionDataProfile))
-		srv.syncWithService()
+		srv.syncWithService(0)
 		if client.count != 1 {
 			t.Error("Expected request")
 		}
@@ -139,7 +139,7 @@ func Test_guardClient_sync_pile(t *testing.T) {
 		client = &fakeHttpClient{statusCode: http.StatusBadRequest, json: bytes}
 		srv.httpClient = client
 
-		srv.syncWithService()
+		srv.syncWithService(0)
 		if client.count != 1 {
 			t.Error("Expected request")
 		}
@@ -151,7 +151,7 @@ func Test_guardClient_sync_pile(t *testing.T) {
 		}
 
 		srv.httpClient = &fakeHttpClient{statusCode: http.StatusOK, json: bytes, err: errors.New("Wow")}
-		srv.syncWithService()
+		srv.syncWithService(0)
 		if client.count != 1 {
 			t.Error("Expected request")
 		}
@@ -163,7 +163,7 @@ func Test_guardClient_sync_pile(t *testing.T) {
 		}
 
 		srv.httpClient = &fakeHttpClient{fail: true}
-		srv.syncWithService()
+		srv.syncWithService(0)
 		if client.count != 1 {
 			t.Error("Expected request")
 		}
@@ -174,7 +174,7 @@ func Test_guardClient_sync_pile(t *testing.T) {
 			t.Errorf("Expected 2 in alert received %d", len(srv.alerts))
 		}
 		srv.httpClient = &fakeHttpClient{statusCode: http.StatusOK, json: bytes}
-		srv.syncWithService()
+		srv.syncWithService(0)
 		if client.count != 1 {
 			t.Error("Expected request")
 		}
@@ -197,7 +197,7 @@ func Test_guardClient_sync_loadGuardian(t *testing.T) {
 		srv, _ := fakeClient(200, string(bytes))
 		g := new(spec.GuardianSpec)
 
-		if got := srv.syncWithService(); !reflect.DeepEqual(got, g) {
+		if got := srv.syncWithService(0); !reflect.DeepEqual(got, g) {
 			t.Errorf("guardClient.loadGuardian() = %v, want %v", got, g)
 		}
 	})

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -200,7 +200,9 @@ func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns 
 		syncServiceSecs = int64(d.Seconds())
 	} else {
 		syncServiceSecs = 60
-		pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", syncInterval, err)
+		if syncInterval != "" {
+			pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", syncInterval, err)
+		}
 	}
 
 	d, err = time.ParseDuration(monitorInterval)
@@ -208,7 +210,9 @@ func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns 
 		podMonitorSecs = int64(d.Seconds())
 	} else {
 		podMonitorSecs = 5
-		pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", monitorInterval, err)
+		if monitorInterval == "" {
+			pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", monitorInterval, err)
+		}
 	}
 
 	p.gateState = NewGateState(ctx, syncServiceSecs, podMonitorSecs, monitorPod, guardServiceUrl, podname, sid, ns, !useCrd, rootCA)

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -38,11 +38,6 @@ const (
 	maxBody    = int64(1048576)
 )
 
-const (
-	syncIntervalDefault       = 60 * time.Second
-	podMonitorIntervalDefault = 5 * time.Second
-)
-
 var errSecurity error = errors.New("security blocked by guard")
 
 type ctxKey string

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -28,8 +28,6 @@ import (
 	_ "net/http/pprof"
 
 	pi "knative.dev/security-guard/pkg/pluginterfaces"
-
-	utils "knative.dev/security-guard/pkg/guard-utils"
 )
 
 const plugVersion string = "0.5"
@@ -54,17 +52,14 @@ type plug struct {
 	version string
 
 	// guard gate plug specifics
-	gateState        *gateState    // maintainer of the criteria and ctrl, include pod profile, gate stats and gate level alert
-	podMonitorTicker *utils.Ticker // tick to gateState.profileAndDecidePod()
-	syncTicker       *utils.Ticker // tick to gateState.sync()
+	gateState *gateState // maintainer of the criteria and ctrl, include pod profile, gate stats and gate level alert
 }
 
 func (p *plug) Shutdown() {
 	pi.Log.Infof("%s Shutdown - performing final Sync!", p.name)
-	p.syncTicker.Stop()
-	p.podMonitorTicker.Stop()
+	ticks := p.gateState.getTicks()
 	if p.gateState.srv.pile.Count > 0 || len(p.gateState.srv.alerts) > 0 {
-		p.gateState.sync(false, true)
+		p.gateState.sync(false, true, ticks)
 	}
 	pi.Log.Infof("%s - Done with the following statistics: %s", p.name, p.gateState.stat.Log())
 	pi.Log.Sync()
@@ -79,12 +74,13 @@ func (p *plug) PlugVersion() string {
 }
 
 func (p *plug) ApproveRequest(req *http.Request) (*http.Request, error) {
+	ticks := p.gateState.getTicks()
 	ctx, cancelFunction := context.WithCancel(req.Context())
 
-	s := newSession(p.gateState, cancelFunction) // maintainer of the profile
+	s := newSession(p.gateState, cancelFunction, ticks) // maintainer of the profile
 
 	// Req
-	s.screenEnvelop()
+	s.screenEnvelop(ticks)
 	s.screenRequest(req)
 	s.screenRequestBody(req)
 
@@ -111,8 +107,7 @@ func (p *plug) ApproveRequest(req *http.Request) (*http.Request, error) {
 
 	req = req.WithContext(ctx)
 
-	//goroutine to accompany the request
-	go s.sessionEventLoop(ctx)
+	p.gateState.Add(ctx, s)
 
 	return req, nil
 }
@@ -124,11 +119,11 @@ func (p *plug) ApproveResponse(req *http.Request, resp *http.Response) (*http.Re
 		pi.Log.Infof("%s ........... Blocked During Response! Missing context!", p.name)
 		return nil, errors.New("missing context")
 	}
-
+	ticks := p.gateState.getTicks()
 	s.gotResponse = true
-	s.screenResponse(resp)
+	s.screenResponse(resp, ticks)
 	s.screenResponseBody(resp)
-	s.screenEnvelop()
+	s.screenEnvelop(ticks)
 
 	if p.gateState.shouldBlock() && (s.hasAlert() || p.gateState.hasAlert()) {
 		p.gateState.addStat("BlockOnResponse")
@@ -140,27 +135,6 @@ func (p *plug) ApproveResponse(req *http.Request, resp *http.Response) (*http.Re
 	return resp, nil
 }
 
-func (p *plug) guardMainEventLoop(ctx context.Context) {
-	p.syncTicker.Start()
-	p.podMonitorTicker.Start()
-	for {
-		select {
-		// Always finish guard here!
-		case <-ctx.Done():
-			pi.Log.Debugf("Terminating the guardMainEventLoop")
-			p.syncTicker.Stop()
-			p.podMonitorTicker.Stop()
-			return
-		// Periodically send pile and alerts and get an updated Guardian
-		case <-p.syncTicker.Ch():
-			p.gateState.syncIfNeeded()
-
-		// Periodically profile of the pod
-		case <-p.podMonitorTicker.Ch():
-			p.gateState.profileAndDecidePod()
-		}
-	}
-}
 func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns string, logger pi.Logger) {
 	var ok bool
 	var v string
@@ -200,12 +174,6 @@ func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns 
 		pi.Log.Infof("guard-gate missing configuration")
 	}
 
-	p.syncTicker = utils.NewTicker(utils.MinimumInterval)
-	p.podMonitorTicker = utils.NewTicker(utils.MinimumInterval)
-
-	p.syncTicker.Parse(syncInterval, syncIntervalDefault)
-	p.podMonitorTicker.Parse(monitorInterval, podMonitorIntervalDefault)
-
 	podname := "unknown"
 	if v, ok = c["podname"]; ok {
 		podname = v
@@ -226,7 +194,24 @@ func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns 
 		panic("Ileal serviceName - ns.{Namespace} is reserved")
 	}
 
-	p.gateState = NewGateState(ctx)
+	var syncServiceSecs, podMonitorSecs int64
+	d, err := time.ParseDuration(syncInterval)
+	if err == nil {
+		syncServiceSecs = int64(d.Seconds())
+	} else {
+		syncServiceSecs = 60
+		pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", syncInterval, err)
+	}
+
+	d, err = time.ParseDuration(monitorInterval)
+	if err == nil {
+		podMonitorSecs = int64(d.Seconds())
+	} else {
+		podMonitorSecs = 5
+		pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", monitorInterval, err)
+	}
+
+	p.gateState = NewGateState(ctx, syncServiceSecs, podMonitorSecs)
 	p.gateState.analyzeBody = analyzeBody
 
 	// p.gateState.init uses a `useCm` flag
@@ -241,11 +226,9 @@ func (p *plug) Init(ctx context.Context, c map[string]string, sid string, ns str
 	// cant be tested as depend on KubeMgr
 	p.gateState.start()
 
-	p.gateState.sync(true, true)
-	p.gateState.profileAndDecidePod()
-
-	//goroutine for Guard instance
-	go p.guardMainEventLoop(ctx)
+	ticks := time.Now().Unix()
+	p.gateState.sync(true, true, ticks)
+	p.gateState.profileAndDecidePod(ticks)
 
 	return ctx
 }

--- a/pkg/guard-gate/gate.go
+++ b/pkg/guard-gate/gate.go
@@ -211,11 +211,8 @@ func (p *plug) preInit(ctx context.Context, c map[string]string, sid string, ns 
 		pi.Log.Errorf("interval illegal value %s - using default value instead (err: %v)", monitorInterval, err)
 	}
 
-	p.gateState = NewGateState(ctx, syncServiceSecs, podMonitorSecs)
+	p.gateState = NewGateState(ctx, syncServiceSecs, podMonitorSecs, monitorPod, guardServiceUrl, podname, sid, ns, !useCrd, rootCA)
 	p.gateState.analyzeBody = analyzeBody
-
-	// p.gateState.init uses a `useCm` flag
-	p.gateState.init(monitorPod, guardServiceUrl, podname, sid, ns, !useCrd, rootCA)
 
 	pi.Log.Infof("guard-gate: Secured Communication %t (CERT Verification %t AUTH Token %t)", p.gateState.srv.certVerifyActive && p.gateState.srv.tokenActive, p.gateState.srv.certVerifyActive, p.gateState.srv.tokenActive)
 }

--- a/pkg/guard-gate/gate_test.go
+++ b/pkg/guard-gate/gate_test.go
@@ -51,7 +51,7 @@ func testInit(c map[string]string) *plug {
 	}
 
 	pi.RegisterPlug(p)
-	p.preInit(c, "svcName", "myns", defaultLog)
+	p.preInit(context.Background(), c, "svcName", "myns", defaultLog)
 	p.gateState = fakeGateState()
 	p.gateState.sync(true, false)
 	return p
@@ -69,7 +69,7 @@ func initTickerTest() *plug {
 
 	pi.RegisterPlug(p)
 
-	p.preInit(c, "svcName", "myns", defaultLog)
+	p.preInit(context.Background(), c, "svcName", "myns", defaultLog)
 	p.gateState = fakeGateState()
 	p.gateState.sync(true, true)
 	p.gateState.stat.Init()
@@ -171,7 +171,7 @@ func Test_plug_Initialize(t *testing.T) {
 			p.syncTicker = utils.NewTicker(utils.MinimumInterval)
 
 			pi.RegisterPlug(p)
-			p.preInit(tt.c, "svcName", "myns", defaultLog)
+			p.preInit(context.Background(), tt.c, "svcName", "myns", defaultLog)
 
 			if tt.monitorPod != p.gateState.monitorPod {
 				t.Errorf("extected monitorPod %t got %t", tt.monitorPod, p.gateState.monitorPod)
@@ -191,7 +191,7 @@ func Test_plug_initPanic(t *testing.T) {
 	t.Run("panic on sid", func(t *testing.T) {
 		defer func() { _ = recover() }()
 		p := new(plug)
-		p.preInit(nil, "ns.svcName", "myns", defaultLog)
+		p.preInit(context.Background(), nil, "ns.svcName", "myns", defaultLog)
 		t.Error("extected to panic")
 	})
 }

--- a/pkg/guard-gate/gate_test.go
+++ b/pkg/guard-gate/gate_test.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	spec "knative.dev/security-guard/pkg/apis/guard/v1alpha1"
-	utils "knative.dev/security-guard/pkg/guard-utils"
 	pi "knative.dev/security-guard/pkg/pluginterfaces"
 )
 
@@ -53,75 +51,8 @@ func testInit(c map[string]string) *plug {
 	pi.RegisterPlug(p)
 	p.preInit(context.Background(), c, "svcName", "myns", defaultLog)
 	p.gateState = fakeGateState()
-	p.gateState.sync(true, false)
+	p.gateState.sync(true, false, p.gateState.getTicks())
 	return p
-}
-
-func initTickerTest() *plug {
-	p := new(plug)
-	p.version = plugVersion
-	p.name = plugName
-
-	c := make(map[string]string)
-	c["guard-url"] = "url"
-	c["use-crd"] = "false"
-	c["monitor-pod"] = "x"
-
-	pi.RegisterPlug(p)
-
-	p.preInit(context.Background(), c, "svcName", "myns", defaultLog)
-	p.gateState = fakeGateState()
-	p.gateState.sync(true, true)
-	p.gateState.stat.Init()
-	return p
-}
-
-func cancelLater(cancel context.CancelFunc) {
-	td, _ := time.ParseDuration("10ms")
-	<-time.After(td)
-	cancel()
-}
-
-func Test_plug_guardMainEventLoop_1(t *testing.T) {
-	t.Run("syncTicker", func(t *testing.T) {
-		p := initTickerTest()
-		p.syncTicker = utils.NewTicker(100000)
-		p.syncTicker.Parse("", 300000)
-		// lets rely on timeout
-		ctx, cancelFunction := context.WithCancel(context.Background())
-		go cancelLater(cancelFunction)
-		p.guardMainEventLoop(ctx)
-		if ret := p.gateState.stat.Log(); ret != "map[]" {
-			t.Errorf("expected stat %s received %s", "map[]", ret)
-		}
-	})
-}
-func Test_plug_guardMainEventLoop_2(t *testing.T) {
-	t.Run("podMonitorTicker", func(t *testing.T) {
-		p := initTickerTest()
-		ctx, cancelFunction := context.WithCancel(context.Background())
-
-		p.podMonitorTicker = utils.NewTicker(100000)
-		p.podMonitorTicker.Parse("", 300000)
-		// lets rely on timeout
-		go cancelLater(cancelFunction)
-		p.guardMainEventLoop(ctx)
-		if ret := p.gateState.stat.Log(); ret != "map[]" {
-			t.Errorf("expected stat %s received %s", "map[]", ret)
-		}
-	})
-}
-
-func Test_plug_guardMainEventLoop_4(t *testing.T) {
-	t.Run("reportPileTicker", func(t *testing.T) {
-		p := initTickerTest()
-		ctx, cancelFunction := context.WithCancel(context.Background())
-		cancelFunction()
-		p.guardMainEventLoop(ctx)
-		if ret := p.gateState.stat.Log(); ret != "map[]" {
-			t.Errorf("expected stat %s received %s", "map[]", ret)
-		}
-	})
 }
 
 func Test_plug_Initialize(t *testing.T) {
@@ -167,8 +98,6 @@ func Test_plug_Initialize(t *testing.T) {
 			p := new(plug)
 			p.version = plugVersion
 			p.name = plugName
-			p.podMonitorTicker = utils.NewTicker(utils.MinimumInterval)
-			p.syncTicker = utils.NewTicker(utils.MinimumInterval)
 
 			pi.RegisterPlug(p)
 			p.preInit(context.Background(), tt.c, "svcName", "myns", defaultLog)
@@ -264,7 +193,7 @@ func Test_plug_ApproveResponse(t *testing.T) {
 		}
 
 		ctx, cancelFunction := context.WithCancel(req.Context())
-		s := newSession(p.gateState, cancelFunction) // maintainer of the profile
+		s := newSession(p.gateState, cancelFunction, p.gateState.getTicks()) // maintainer of the profile
 		ctx = s.addSessionToContext(ctx)
 		ctx = context.WithValue(ctx, ctxKey("GuardSession"), s)
 

--- a/pkg/guard-gate/state.go
+++ b/pkg/guard-gate/state.go
@@ -19,9 +19,11 @@ package guardgate
 import (
 	"context"
 	"crypto/x509"
+	"sync"
 	"time"
 
 	spec "knative.dev/security-guard/pkg/apis/guard/v1alpha1"
+	"knative.dev/security-guard/pkg/dselect"
 	utils "knative.dev/security-guard/pkg/guard-utils"
 	"knative.dev/security-guard/pkg/iodup"
 	pi "knative.dev/security-guard/pkg/pluginterfaces"
@@ -32,39 +34,61 @@ func logAlert(alert string) {
 }
 
 type gateState struct {
-	analyzeBody  bool
-	ctrl         *spec.Ctrl              // gate Ctrl
-	criteria     *spec.SessionDataConfig // gate Criteria
-	numSamples   uint32                  // number of samples used to create the Guardian
-	stat         utils.Stat              // gate stats
-	alert        string                  // gate alert
-	decision     *spec.Decision          // gate alert decision
-	monitorPod   bool                    // should gate profile the pod?
-	pod          spec.PodProfile         // pod profile
-	srv          *gateClient             // maintainer of the pile, include client to the guard-service & kubeApi
-	certPool     *x509.CertPool          // rootCAs
-	prevAlert    string                  // previous gate alert
-	skippedSyncs uint32                  // how many times we skipped sync?
-	lastSync     int64                   // last time we synced
-	iodups       *iodup.IoDups
-	ticks        int64
+	analyzeBody     bool
+	ctrl            *spec.Ctrl              // gate Ctrl
+	criteria        *spec.SessionDataConfig // gate Criteria
+	numSamples      uint32                  // number of samples used to create the Guardian
+	stat            utils.Stat              // gate stats
+	alert           string                  // gate alert
+	decision        *spec.Decision          // gate alert decision
+	monitorPod      bool                    // should gate profile the pod?
+	pod             spec.PodProfile         // pod profile
+	srv             *gateClient             // maintainer of the pile, include client to the guard-service & kubeApi
+	certPool        *x509.CertPool          // rootCAs
+	prevAlert       string                  // previous gate alert
+	skippedSyncs    uint32                  // how many times we skipped sync?
+	lastSync        int64                   // last time we synced
+	iodups          *iodup.IoDups
+	ticks           int64
+	ticksMutex      sync.Mutex
+	dselect         *dselect.DSelect
+	syncServiceSecs int64
+	podMonitorSecs  int64
 }
 
-func NewGateState(ctx context.Context) *gateState {
+func NewGateState(ctx context.Context, syncServiceSecs int64, podMonitorSecs int64) *gateState {
 	gs := new(gateState)
 	gs.ticks = time.Now().Unix()
-	ticker := time.NewTicker(time.Second)
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case t := <-ticker.C:
-				gs.ticks = t.Unix()
-			}
-		}
-	}()
+	gs.syncServiceSecs = syncServiceSecs
+	gs.podMonitorSecs = podMonitorSecs
+	gs.dselect = dselect.NewDSelect(ctx, gs.setTicks)
 	return gs
+}
+
+func (gs *gateState) getTicks() int64 {
+	gs.ticksMutex.Lock()
+	defer gs.ticksMutex.Unlock()
+	return gs.ticks
+}
+
+func (gs *gateState) setTicks(ticks int64) {
+	gs.ticksMutex.Lock()
+	gs.ticks = ticks
+	gs.ticksMutex.Unlock()
+
+	// Periodically sync to guard-service
+	if ticks%gs.syncServiceSecs == 0 {
+		gs.syncIfNeeded(ticks)
+	}
+
+	// Periodically profile of the pod
+	if ticks%gs.podMonitorSecs == 1 {
+		gs.profileAndDecidePod(ticks)
+	}
+}
+
+func (gs *gateState) Add(ctx context.Context, s *session) {
+	gs.dselect.Add(ctx, s.tick, s.complete, 5)
 }
 
 func (gs *gateState) init(monitorPod bool, guardServiceUrl string, podname string, sid string, ns string, useCm bool, rootCA string) {
@@ -99,7 +123,7 @@ func (gs *gateState) init(monitorPod bool, guardServiceUrl string, podname strin
 	gs.srv.initHttpClient(gs.certPool, skipVerify)
 }
 
-func (gs gateState) start() {
+func (gs *gateState) start() {
 	// Skip during simulations
 	if len(gs.srv.ns) > 0 {
 		// initializtion that cant be tested due to use of KubeAMgr
@@ -108,14 +132,14 @@ func (gs gateState) start() {
 }
 
 // sync is called periodically to send pile and alerts and to load from the updated Guardian
-func (gs *gateState) sync(shouldLoad bool, forceSync bool) {
-	if !forceSync && (gs.ticks-gs.lastSync) < MIN_TIME_BETWEEN_SYNCS {
+func (gs *gateState) sync(shouldLoad bool, forceSync bool, ticks int64) {
+	if !forceSync && (ticks-gs.lastSync) < MIN_TIME_BETWEEN_SYNCS {
 		return
 	}
 
 	gs.skippedSyncs = 0
 	// send pile and alerts and get Guardian - never returns nil!
-	g := gs.srv.syncWithServiceAndKubeApi(shouldLoad)
+	g := gs.srv.syncWithServiceAndKubeApi(ticks, shouldLoad)
 	if !shouldLoad {
 		return
 	}
@@ -145,31 +169,32 @@ func (gs *gateState) sync(shouldLoad bool, forceSync bool) {
 	pi.Log.Debugf("Loading Guardian  - Active %t Auto %t Block %t", gs.criteria.Active, gs.ctrl.Auto, gs.ctrl.Block)
 }
 
-func (gs *gateState) syncIfNeeded() {
+func (gs *gateState) syncIfNeeded(ticks int64) {
 	// if we have 10% new samples or more (otherwise wait till we get to 1000 samples)
 	if gs.numSamples < gs.srv.pile.Count*10 || len(gs.srv.alerts) > 0 {
-		gs.sync(true, false)
+		gs.sync(true, false, ticks)
+		return
 	}
 
 	// if we skipped 4 times, then this time we will sync
 	// 5 min for the default 1 min syncInterval
 	gs.skippedSyncs++
 	if gs.skippedSyncs >= 5 {
-		gs.sync(true, false)
+		gs.sync(true, false, ticks)
 	}
 }
 
 // addProfile is called every time we have a new profile ready to be added to a pile
-func (gs *gateState) addProfile(profile *spec.SessionDataProfile) {
+func (gs *gateState) addProfile(profile *spec.SessionDataProfile, ticks int64) {
 	if gs.srv.addToPile(profile) >= PILE_LIMIT {
-		gs.sync(true, false)
+		gs.sync(true, false, ticks)
 	}
 }
 
 // addAlert is called every time we have a new alert
 func (gs *gateState) addAlert(decision *spec.Decision, level string) {
 	if gs.srv.addAlert(decision, level) >= ALERTS_LIMIT {
-		gs.sync(true, false)
+		gs.sync(true, false, gs.getTicks())
 	}
 }
 
@@ -177,15 +202,15 @@ func (gs *gateState) addAlert(decision *spec.Decision, level string) {
 // Enables the POD profile to be copied to the sessio  profile for reporting to pile.
 
 // profileAndDecidePod is called periodically to profile the pod and decide if to raise an alert
-func (gs *gateState) profileAndDecidePod() {
+func (gs *gateState) profileAndDecidePod(ticks int64) {
 	if !gs.monitorPod {
 		return
 	}
-	//First profile
+	// First profile
 	gs.pod.Profile()
 
 	// Now decide
-	// Current behaviour is latching the alert forever
+	// Current behavior is latching the alert forever
 	// This makes sense from security standpoint as the pod is now considered contaminated
 	// If we are blocking, this means we will simply keep blocking all requests forever
 	// Therefore we terminate the reverse proxy
@@ -195,7 +220,7 @@ func (gs *gateState) profileAndDecidePod() {
 		if gs.decision != nil {
 			gs.logAlert()
 			if gs.shouldBlock() {
-				gs.srv.signalCompromised(gs.ticks)
+				gs.srv.signalCompromised(ticks)
 				// Terminate the reverse proxy since all requests will block from now on
 				pi.Log.Infof("Terminating")
 				gs.addStat("BlockOnPod")

--- a/pkg/guard-gate/state_test.go
+++ b/pkg/guard-gate/state_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package guardgate
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 
 	spec "knative.dev/security-guard/pkg/apis/guard/v1alpha1"
 )
@@ -30,7 +30,7 @@ import (
 var gateCanceled int
 
 func fakeGateState() *gateState {
-	gs := new(gateState)
+	gs := NewGateState(context.Background())
 	gs.init(false, "myurl", "mypodname", "mysid", "myns", true, "")
 	bytes, _ := json.Marshal(spec.Guardian{})
 	srv, _ := fakeClient(http.StatusOK, string(bytes))
@@ -86,14 +86,14 @@ func Test_gateState_sync(t *testing.T) {
 
 		// envelop
 		ep := new(spec.EnvelopProfile)
-		now := time.Now()
+		now := int64(1000)
 		ep.Profile(now, now, now)
 		decision = nil
 		if gs.decideEnvelop(&decision, ep); decision != nil {
 			t.Error("expected no alert")
 		}
 		decision = nil
-		ep.Profile(time.Unix(1, 1), time.Unix(3, 3), time.Unix(5, 5))
+		ep.Profile(1, 3, 2)
 		if gs.decideEnvelop(&decision, ep); decision == nil {
 			t.Error("expected alert")
 		}

--- a/pkg/guard-gate/state_test.go
+++ b/pkg/guard-gate/state_test.go
@@ -31,8 +31,7 @@ import (
 var gateCanceled int
 
 func fakeGateState() *gateState {
-	gs := NewGateState(context.Background(), 1, 1)
-	gs.init(false, "myurl", "mypodname", "mysid", "myns", true, "")
+	gs := NewGateState(context.Background(), 1, 1, false, "myurl", "mypodname", "mysid", "myns", true, "")
 	bytes, _ := json.Marshal(spec.Guardian{})
 	srv, _ := fakeClient(http.StatusOK, string(bytes))
 	gs.srv = srv

--- a/pkg/guard-gate/state_test.go
+++ b/pkg/guard-gate/state_test.go
@@ -18,6 +18,7 @@ package guardgate
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -30,7 +31,7 @@ import (
 var gateCanceled int
 
 func fakeGateState() *gateState {
-	gs := NewGateState(context.Background())
+	gs := NewGateState(context.Background(), 1, 1)
 	gs.init(false, "myurl", "mypodname", "mysid", "myns", true, "")
 	bytes, _ := json.Marshal(spec.Guardian{})
 	srv, _ := fakeClient(http.StatusOK, string(bytes))
@@ -44,12 +45,12 @@ func Test_gateState_sync(t *testing.T) {
 
 		gs := fakeGateState()
 
-		gs.sync(true, false)
+		gs.sync(true, false, gs.getTicks())
 		if gs.criteria == nil || gs.ctrl == nil {
 			t.Error("nil after load")
 		}
 		gs.criteria.Active = false
-		gs.profileAndDecidePod()
+		gs.profileAndDecidePod(gs.getTicks())
 		if gateCanceled != 0 {
 			t.Error("expected no cancel")
 		}
@@ -59,7 +60,7 @@ func Test_gateState_sync(t *testing.T) {
 		gs.monitorPod = true
 		gs.criteria.Active = true
 		gateCanceled = 0
-		gs.profileAndDecidePod()
+		gs.profileAndDecidePod(gs.getTicks())
 
 		var pp spec.PodProfile
 		gs.monitorPod = false
@@ -152,16 +153,16 @@ func Test_gateState_sync(t *testing.T) {
 			t.Error("expected alert")
 		}
 
-		gs.sync(true, false)
+		gs.sync(true, false, gs.getTicks())
 		if gs.srv.pile.Count != 0 {
 			t.Error("expected pile too have 1")
 		}
 		profile := new(spec.SessionDataProfile)
-		gs.addProfile(profile)
+		gs.addProfile(profile, gs.getTicks())
 		if gs.srv.pile.Count != 1 {
 			t.Error("expected pile too have 1")
 		}
-		gs.sync(true, false)
+		gs.sync(true, false, gs.getTicks())
 		if gs.srv.pile.Count != 0 {
 			t.Error("expected pile too have 0")
 		}
@@ -192,15 +193,15 @@ func Test_gateState_init(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gs := new(gateState)
-			// certPool, _ := x509.SystemCertPool()
+			certPool, _ := x509.SystemCertPool()
 			gs.init(false, "myurl", "mypodname", "mysid", "myns", true, tt.cert)
 			// TBD will be added when we move to go 1.19
-			// if !certPool.Equal(gs.certPool) && !tt.newCA {
-			// 	 t.Errorf("expected no new cert to be added")
-			// }
-			// if certPool.Equal(gs.certPool) && tt.newCA {
-			//	 t.Errorf("expected new cert to be added")
-			// }
+			if !certPool.Equal(gs.certPool) && !tt.newCA {
+				t.Errorf("expected no new cert to be added")
+			}
+			if certPool.Equal(gs.certPool) && tt.newCA {
+				t.Errorf("expected new cert to be added")
+			}
 		})
 	}
 }

--- a/pkg/qpoption/qpoption.go
+++ b/pkg/qpoption/qpoption.go
@@ -131,11 +131,15 @@ func (p *GateQPOption) ProcessAnnotations() bool {
 	var buf []byte
 	buf, err = os.ReadFile(path.Join(queue.CertDirectory, certificates.CaCertName))
 	if err != nil {
-		// lets try the older secret names
-		pi.Log.Debugf("RootCa (%s) is missing", path.Join(queue.CertDirectory, certificates.CaCertName))
-		buf, err = os.ReadFile(path.Join(queue.CertDirectory, certificates.SecretCaCertKey))
-		if err != nil {
-			pi.Log.Debugf("RootCa (%s) is missing - Insecure communication, working without TLS RootCA!", path.Join(queue.CertDirectory, certificates.SecretCaCertKey))
+		if rootCA := os.Getenv("ROOT_CA"); rootCA != "" {
+			p.config["rootca"] = rootCA
+		} else {
+			// lets try the older secret names
+			pi.Log.Debugf("RootCa (%s) is missing", path.Join(queue.CertDirectory, certificates.CaCertName))
+			buf, err = os.ReadFile(path.Join(queue.CertDirectory, certificates.SecretCaCertKey))
+			if err != nil {
+				pi.Log.Debugf("RootCa (%s) is missing - Insecure communication, working without TLS RootCA!", path.Join(queue.CertDirectory, certificates.SecretCaCertKey))
+			}
 		}
 	}
 	if err == nil {


### PR DESCRIPTION
Main changes
1. Removed excessive mallocs per session by caching iodups
2. Removed frequent time.Now()
3. Removed extra goroutine per session by introducing `dselect` pkg that uses dynamic select using reflect.Select 
4. Merged tickers to a unified ticker 
5. Cashe tokens 

Also fixed bug  - missing mutex when doing pile.Clear()